### PR TITLE
Add basic version of "Instrument" & "DAQ" classes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,18 @@
 from blocks import Blocks, Stimulation
+from controls import DAQ, Instrument
 
+instruments = {
+    'infrared': Instrument('port1'),
+    'red': Instrument('port2'),
+    'green': Instrument('port3'),
+    'blue': Instrument('port4'),
+    'air_pump': Instrument('port5'),
+    'camera': Instrument('port6')
+}
+new_daq = DAQ('acquisition', instruments)
 
-a = Stimulation(100, 4, 4, 1, delay=200, type='random-square')
-b = Stimulation(200, 4, 8, 1, delay=50, type='random-square')
+a = Stimulation(100, 4, 4, 1, delay=200, pulse_type='random-square')
+b = Stimulation(200, 4, 8, 1, delay=50, pulse_type='random-square')
 c = Blocks([a], iterations=2)
 d = Blocks([b], iterations=3)
 e = Blocks([c,d], delay=2, iterations=2)

--- a/controls.py
+++ b/controls.py
@@ -1,0 +1,39 @@
+import nidaqmx
+
+
+
+class Instrument:
+    def __init__(self, port):
+        self.port = port
+
+    def analog_read(self):
+        with nidaqmx.Task() as task:
+            task.ai_channels.add_ai_voltage_chan(f"{self.daq.name}/{self.port}")
+            value = task.read()
+            print(value)
+
+    def analog_write(self):
+        with nidaqmx.Task() as task:
+            task.co_channels.add_co_pulse_chan_time(f"{self.daq.name}/{self.port}")
+            task.write(2)
+
+
+    def digital_write(self):
+        with nidaqmx.Task() as task:
+            task.co_channels.add_co_pulse_chan_time(f"{self.daq.name}/{self.port}")
+            task.write(True)
+
+    def digital_read(self):
+        with nidaqmx.Task() as task:
+            task.co_channels.add_co_pulse_chan_time(f"{self.daq.name}/{self.port}")
+            value = task.read()
+            print(value)
+
+class DAQ:
+    def __init__(self, name, instruments):
+        self.name = name
+        self.instruments = instruments
+
+    def launch(self):
+        pass
+

--- a/daq_tests.py
+++ b/daq_tests.py
@@ -12,12 +12,12 @@ def analog_write():
         task.write(2)
 
 
-def digital_read():
+def digital_write():
     with nidaqmx.Task() as task:
         task.co_channels.add_co_pulse_chan_time("Dev1/port0/line0")
         task.write(True)
 
-def digital_write():
+def digital_read():
     with nidaqmx.Task() as task:
         task.co_channels.add_co_pulse_chan_time("Dev1/port0/line1")
         value = task.read()


### PR DESCRIPTION
The DAQ acts as a container for the different Instruments used.
Future methods will be implemented to run the instruments together.
The "Instrument" class contains the location of the instrument.
In the future, it will also contains informations on the state of each
instrument (closed, open, ...) which will be used to generate reports.