### PR TITLE
Fix frames saving without ROI

### DIFF
--- a/src/controls.py
+++ b/src/controls.py
@@ -9,7 +9,7 @@ from src.signal_generator import digital_square
 from src.data_handling import shrink_array, find_rising_indices, create_complete_stack, reduce_stack
 from pylablib.devices import IMAQ
 import warnings
-#warnings.filterwarnings("ignore")
+warnings.filterwarnings("ignore")
 
 WIDEFIELD_COMPUTER = True
 class Instrument:
@@ -76,8 +76,6 @@ class Camera(Instrument):
         """
         if extents:
             self.frames = shrink_array(self.frames, extents)
-        print(len(self.frames))
-        print(len(self.frames[0]))
         np.save(f"{directory}/{self.daq.experiment_name}-data", self.frames)
 
 

--- a/src/data_handling.py
+++ b/src/data_handling.py
@@ -2,14 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 def shrink_array(array, extents):
-    print(extents)
-    print(round(extents[0]))
-    print("array size on enter")
-    print(len(array[0]))
-    new_array = array[:,round(extents[0]):round(extents[1]), round(extents[2]):round(extents[3])]
-    #new_array = array[:,round(extents[0]):round(extents[1])]
-    print("array size on close")
-    return array
+    return np.array(array)[:,round(extents[0]):round(extents[1]), round(extents[2]):round(extents[3])]
 
 def get_array(directory):
     return np.load(directory)


### PR DESCRIPTION
3D slicing did not work because the input received was a list of 2D arrays rather than a 3D numpy array.